### PR TITLE
add: forgot password feature

### DIFF
--- a/lib/presentation/forgot_password/forgot_password_model.dart
+++ b/lib/presentation/forgot_password/forgot_password_model.dart
@@ -1,0 +1,33 @@
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/material.dart';
+
+class ForgotPasswordModel extends ChangeNotifier {
+  final TextEditingController email = TextEditingController();
+  final FirebaseAuth _auth = FirebaseAuth.instance;
+  bool isLoading = false;
+  bool isSendMail = false;
+
+  void beginLoading() {
+    isLoading = true;
+    notifyListeners();
+  }
+
+  void endLoading() {
+    isLoading = false;
+    notifyListeners();
+  }
+
+  Future sendPasswordResetEmail() async {
+    await _auth.sendPasswordResetEmail(email: this.email.text);
+  }
+
+  Future showMessage() async {
+    isSendMail = true;
+    notifyListeners();
+
+    await Future.delayed(Duration(milliseconds: 5000));
+
+    isSendMail = false;
+    notifyListeners();
+  }
+}

--- a/lib/presentation/forgot_password/forgot_password_page.dart
+++ b/lib/presentation/forgot_password/forgot_password_page.dart
@@ -1,0 +1,178 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'forgot_password_model.dart';
+
+class ForgotPassword extends StatelessWidget {
+  final _formKey = GlobalKey<FormState>();
+
+  Future _submit(BuildContext context, ForgotPasswordModel model) async {
+    if (!_formKey.currentState.validate()) {
+      return;
+    }
+
+    FocusScope.of(context).unfocus();
+
+    try {
+      model.beginLoading();
+
+      await model.sendPasswordResetEmail();
+
+      model.endLoading();
+
+      await model.showMessage();
+    } catch (e) {
+      model.endLoading();
+      await _showDialog(context, e.toString());
+    }
+  }
+
+  Future _showDialog(BuildContext context, String errorText) async {
+    await showDialog(
+      context: context,
+      builder: (BuildContext context) {
+        return AlertDialog(
+          title: Text('エラー'),
+          content: Text(errorText),
+          actions: <Widget>[
+            FlatButton(
+              child: Text(
+                'OK',
+                style: TextStyle(
+                  color: Colors.blueAccent,
+                ),
+              ),
+              onPressed: () => Navigator.pop(context),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  Widget _buildLoading(ForgotPasswordModel model) {
+    if (!model.isLoading) {
+      return SizedBox();
+    }
+
+    return Container(
+      color: Colors.white.withOpacity(0.6),
+      child: Center(
+        child: CircularProgressIndicator(),
+      ),
+    );
+  }
+
+  Widget _buildMessage(BuildContext context, ForgotPasswordModel model) {
+    final deviceSize = MediaQuery.of(context).size;
+
+    return AnimatedOpacity(
+      duration: Duration(milliseconds: 200),
+      opacity: model.isSendMail ? 1 : 0,
+      child: Container(
+        width: deviceSize.width,
+        padding: EdgeInsets.all(15),
+        margin: EdgeInsets.all(15),
+        decoration: BoxDecoration(
+          color: Color(0xff203152),
+          borderRadius: BorderRadius.circular(8),
+        ),
+        child: Text(
+          'パスワード再設定メールを送信しました',
+          style: TextStyle(
+            color: Colors.white,
+            fontSize: 15,
+          ),
+        ),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ChangeNotifierProvider<ForgotPasswordModel>(
+      create: (_) => ForgotPasswordModel(),
+      child: Consumer<ForgotPasswordModel>(
+        builder: (_, model, __) {
+          return Stack(
+            children: <Widget>[
+              GestureDetector(
+                onTap: () {
+                  FocusScope.of(context).unfocus();
+                },
+                child: Scaffold(
+                  appBar: AppBar(
+                    title: Text('パスワード再設定'),
+                    actions: <Widget>[
+                      ButtonTheme(
+                        minWidth: 0,
+                        child: FlatButton(
+                          materialTapTargetSize:
+                              MaterialTapTargetSize.shrinkWrap,
+                          child: Text(
+                            '送信',
+                            style: TextStyle(
+                              color: Theme.of(context).primaryColor,
+                              fontWeight: FontWeight.bold,
+                              fontSize: 18,
+                            ),
+                          ),
+                          onPressed: () async {
+                            await _submit(context, model);
+                          },
+                        ),
+                      ),
+                    ],
+                  ),
+                  body: SafeArea(
+                    child: Stack(
+                      alignment: Alignment.bottomCenter,
+                      children: <Widget>[
+                        Container(
+                          padding: EdgeInsets.all(15),
+                          child: Column(
+                            children: <Widget>[
+                              Text(
+                                'ご登録いただいたメールアドレスを入力すると、パスワード変更ページが記載されたメールを送信します。',
+                                style: TextStyle(
+                                  fontSize: 15,
+                                ),
+                              ),
+                              SizedBox(height: 10),
+                              Form(
+                                key: _formKey,
+                                child: TextFormField(
+                                  controller: model.email,
+                                  autofocus: true,
+                                  keyboardType: TextInputType.emailAddress,
+                                  validator: (value) {
+                                    if (value.trim().isEmpty) {
+                                      return '入力してください。';
+                                    }
+
+                                    return null;
+                                  },
+                                  decoration: InputDecoration(
+                                    hintText: 'メールアドレス',
+                                  ),
+                                  onFieldSubmitted: (_) async {
+                                    await _submit(context, model);
+                                  },
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
+                        _buildMessage(context, model),
+                      ],
+                    ),
+                  ),
+                ),
+              ),
+              _buildLoading(model),
+            ],
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/presentation/setting_password/setting_password_page.dart
+++ b/lib/presentation/setting_password/setting_password_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:takutore/presentation/forgot_password/forgot_password_page.dart';
 import '../../atoms/rounded_button.dart';
 import '../common/loading.dart';
 import '../../user_model.dart';
@@ -72,151 +73,177 @@ class _CurrentPasswordSectionState extends State<CurrentPasswordSection> {
     });
   }
 
+  Future _submit(UserModel model) async {
+    try {
+      await model.updatePassword(
+        currentPassword: _currentPasswordController.text,
+        newPassword: _newPasswordController.text,
+        newPasswordConfirm: _newPasswordConfirmController.text,
+      );
+      await showDialog(
+        context: context,
+        builder: (BuildContext context) {
+          return AlertDialog(
+            title: Text('パスワードを更新しました。'),
+            actions: <Widget>[
+              FlatButton(
+                child: Text('OK'),
+                onPressed: () => Navigator.pop(context),
+              ),
+            ],
+          );
+        },
+      );
+      model.checkUserSignIn();
+      Navigator.pop(context);
+    } catch (error) {
+      model.endLoading();
+      showDialog(
+        context: context,
+        builder: (BuildContext context) {
+          return AlertDialog(
+            title: Text(error.toString()),
+            actions: <Widget>[
+              FlatButton(
+                child: Text('OK'),
+                onPressed: () => Navigator.pop(context),
+              ),
+            ],
+          );
+        },
+      );
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
-    return Consumer<UserModel>(builder: (_, model, __) {
-      return SingleChildScrollView(
-        child: Padding(
-          padding: EdgeInsets.all(16),
-          child: SafeArea(
-            child: Form(
-              key: _formKey,
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: <Widget>[
-                  Text(
-                    '現在のパスワード',
-                    style: TextStyle(
-                      fontWeight: FontWeight.bold,
+    return Consumer<UserModel>(
+      builder: (_, model, __) {
+        return SingleChildScrollView(
+          child: Padding(
+            padding: EdgeInsets.all(16),
+            child: SafeArea(
+              child: Form(
+                key: _formKey,
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: <Widget>[
+                    Text(
+                      '現在のパスワード',
+                      style: TextStyle(
+                        fontWeight: FontWeight.bold,
+                      ),
                     ),
-                  ),
-                  TextFormField(
-                    controller: _currentPasswordController,
-                    validator: (value) {
-                      if (value.trim().isEmpty) {
-                        return '入力してください。';
-                      }
+                    TextFormField(
+                      controller: _currentPasswordController,
+                      validator: (value) {
+                        if (value.trim().isEmpty) {
+                          return '入力してください。';
+                        }
 
-                      return null;
-                    },
-                    obscureText: true,
-                    onChanged: (value) {
-                      this.isNotEmptyField();
-                    },
-                  ),
-                  SizedBox(height: 20),
-                  Text(
-                    '新しいパスワード',
-                    style: TextStyle(
-                      fontWeight: FontWeight.bold,
+                        return null;
+                      },
+                      obscureText: true,
+                      onChanged: (value) {
+                        this.isNotEmptyField();
+                      },
                     ),
-                  ),
-                  TextFormField(
-                    controller: _newPasswordController,
-                    validator: (value) {
-                      if (value.trim().isEmpty) {
-                        return '入力してください。';
-                      }
-
-                      return null;
-                    },
-                    obscureText: true,
-                    onChanged: (value) {
-                      this.isNotEmptyField();
-                    },
-                  ),
-                  SizedBox(height: 20),
-                  Text(
-                    '新しいパスワードの確認',
-                    style: TextStyle(
-                      fontWeight: FontWeight.bold,
-                    ),
-                  ),
-                  TextFormField(
-                    controller: _newPasswordConfirmController,
-                    validator: (value) {
-                      if (value.trim().isEmpty) {
-                        return '入力してください。';
-                      }
-
-                      return null;
-                    },
-                    obscureText: true,
-                    onChanged: (value) {
-                      this.isNotEmptyField();
-                    },
-                  ),
-                  SizedBox(height: 30),
-                  Center(
-                    child: !isUpdating
-                        ? RoundedButton(
-                            color: Theme.of(context).primaryColor,
-                            child: Text(
-                              '更新',
-                              style: TextStyle(
-                                fontSize: 16,
-                                fontWeight: FontWeight.bold,
-                                color: Colors.white,
-                              ),
+                    Align(
+                      alignment: Alignment.centerRight,
+                      child: ButtonTheme(
+                        minWidth: 0,
+                        padding: EdgeInsets.all(0),
+                        child: FlatButton(
+                          materialTapTargetSize:
+                              MaterialTapTargetSize.shrinkWrap,
+                          child: Text(
+                            'パスワードをお忘れですか？',
+                            style: TextStyle(
+                              color: Theme.of(context).primaryColor,
                             ),
-                            onPressed: !isDisabled
-                                ? () async {
-                                    // TODO: Implement update password processing.
-                                    try {
-                                      await model.updatePassword(
-                                        currentPassword:
-                                            _currentPasswordController.text,
-                                        newPassword:
-                                            _newPasswordController.text,
-                                        newPasswordConfirm:
-                                            _newPasswordConfirmController.text,
-                                      );
-                                      await showDialog(
-                                        context: context,
-                                        builder: (BuildContext context) {
-                                          return AlertDialog(
-                                            title: Text('パスワードを更新しました。'),
-                                            actions: <Widget>[
-                                              FlatButton(
-                                                child: Text('OK'),
-                                                onPressed: () =>
-                                                    Navigator.pop(context),
-                                              ),
-                                            ],
-                                          );
-                                        },
-                                      );
-                                      model.checkUserSignIn();
-                                      Navigator.pop(context);
-                                    } catch (error) {
-                                      model.endLoading();
-                                      showDialog(
-                                        context: context,
-                                        builder: (BuildContext context) {
-                                          return AlertDialog(
-                                            title: Text(error.toString()),
-                                            actions: <Widget>[
-                                              FlatButton(
-                                                child: Text('OK'),
-                                                onPressed: () =>
-                                                    Navigator.pop(context),
-                                              ),
-                                            ],
-                                          );
-                                        },
-                                      );
+                          ),
+                          onPressed: () {
+                            Navigator.push(
+                              context,
+                              MaterialPageRoute(
+                                builder: (BuildContext context) =>
+                                    ForgotPassword(),
+                              ),
+                            );
+                          },
+                        ),
+                      ),
+                    ),
+                    SizedBox(height: 20),
+                    Text(
+                      '新しいパスワード',
+                      style: TextStyle(
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                    TextFormField(
+                      controller: _newPasswordController,
+                      validator: (value) {
+                        if (value.trim().isEmpty) {
+                          return '入力してください。';
+                        }
+
+                        return null;
+                      },
+                      obscureText: true,
+                      onChanged: (value) {
+                        this.isNotEmptyField();
+                      },
+                    ),
+                    SizedBox(height: 20),
+                    Text(
+                      '新しいパスワードの確認',
+                      style: TextStyle(
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                    TextFormField(
+                      controller: _newPasswordConfirmController,
+                      validator: (value) {
+                        if (value.trim().isEmpty) {
+                          return '入力してください。';
+                        }
+
+                        return null;
+                      },
+                      obscureText: true,
+                      onChanged: (value) {
+                        this.isNotEmptyField();
+                      },
+                    ),
+                    SizedBox(height: 30),
+                    Center(
+                      child: !isUpdating
+                          ? RoundedButton(
+                              color: Theme.of(context).primaryColor,
+                              child: Text(
+                                '更新',
+                                style: TextStyle(
+                                  fontSize: 16,
+                                  fontWeight: FontWeight.bold,
+                                  color: Colors.white,
+                                ),
+                              ),
+                              onPressed: !isDisabled
+                                  ? () async {
+                                      await _submit(model);
                                     }
-                                  }
-                                : null,
-                          )
-                        : CircularProgressIndicator(),
-                  ),
-                ],
+                                  : null,
+                            )
+                          : CircularProgressIndicator(),
+                    ),
+                  ],
+                ),
               ),
             ),
           ),
-        ),
-      );
-    });
+        );
+      },
+    );
   }
 }


### PR DESCRIPTION
**Purpose**
Fix #22

**Change content**
Add forgot password feature

**Screenshot**
1. Navigation from setting password page to forgot password page.
<img src='https://user-images.githubusercontent.com/36891892/89051997-04f2e500-d390-11ea-95a5-5913547a9692.png' width=300 />

2. Fill in current email address, and send password reset mail.
<img src='https://user-images.githubusercontent.com/36891892/89052008-06241200-d390-11ea-8592-b7b18c7b3ba3.png' width=300 />

3. If success, the app shows message.
<img src='https://user-images.githubusercontent.com/36891892/89052009-06bca880-d390-11ea-99e4-03d4b4981f2c.png' width=300 />
