### PR TITLE
add: implement a feature for reporting user

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.pyc
 *.swp
 .DS_Store
+.env*
 .atom/
 .buildlog/
 .history

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:provider/provider.dart';
 import 'package:timeago/timeago.dart';
 import 'presentation/auth/auth_page.dart';
@@ -6,9 +7,10 @@ import 'bottom_tab_navigator.dart';
 import 'presentation/common/loading.dart';
 import 'user_model.dart';
 
-void main() {
+void main() async {
   WidgetsFlutterBinding.ensureInitialized();
   setLocaleMessages('ja', JaMessages());
+  await DotEnv().load('.env');
 
   runApp(MyApp());
 }

--- a/lib/presentation/home/home_model.dart
+++ b/lib/presentation/home/home_model.dart
@@ -131,4 +131,24 @@ class HomeModel extends ChangeNotifier {
       },
     );
   }
+
+  Future report({User user, String contentType}) async {
+    final contentTypes = ['inappropriate', 'spam'];
+
+    if (!contentTypes.contains(contentType)) return;
+
+    final currentUser = await FirebaseAuth.instance.currentUser();
+
+    if (user.uid == currentUser.uid) return;
+
+    final collection = Firestore.instance.collection('reports');
+    await collection.add(
+      {
+        'userID': user.uid,
+        'senderID': currentUser.uid,
+        'contentType': contentType,
+        'createdAt': FieldValue.serverTimestamp(),
+      },
+    );
+  }
 }

--- a/lib/presentation/home/home_page.dart
+++ b/lib/presentation/home/home_page.dart
@@ -8,6 +8,31 @@ import 'home_model.dart';
 class Home extends StatelessWidget {
   final _scaffoldKey = new GlobalKey<ScaffoldState>();
 
+  Future _alertDialog(BuildContext context, {String errorText}) async {
+    return await showDialog(
+      context: context,
+      builder: (BuildContext context) {
+        return AlertDialog(
+          title: Text('エラー'),
+          content: Text(errorText),
+          actions: <Widget>[
+            FlatButton(
+              child: Text(
+                'OK',
+                style: TextStyle(
+                  color: Colors.blueAccent,
+                ),
+              ),
+              onPressed: () {
+                Navigator.pop(context);
+              },
+            ),
+          ],
+        );
+      },
+    );
+  }
+
   Future<bool> _confirmDialog(BuildContext context, User teacher) async {
     return await showDialog(
       context: context,
@@ -44,6 +69,35 @@ class Home extends StatelessWidget {
         );
       },
     );
+  }
+
+  Future _report(BuildContext context,
+      {HomeModel model, User teacher, String contentType}) async {
+    final types = ['inappropriate', 'spam'];
+    try {
+      if (!types.contains(contentType)) {
+        throw ('適切な報告内容を選択してください。');
+      }
+
+      await model.report(
+        user: teacher,
+        contentType: 'inappropriate',
+      );
+
+      Navigator.pop(context);
+
+      _scaffoldKey.currentState.showSnackBar(
+        SnackBar(
+          content: Text('ご報告ありがとうございます'),
+        ),
+      );
+    } catch (e) {
+      Navigator.pop(context);
+      this._alertDialog(
+        context,
+        errorText: e.toString(),
+      );
+    }
   }
 
   Future _addBlocked(BuildContext context,
@@ -154,17 +208,11 @@ class Home extends StatelessWidget {
                                     ),
                                   ),
                                   onPressed: () async {
-                                    await model.report(
-                                      user: teacher,
+                                    await this._report(
+                                      context,
+                                      model: model,
+                                      teacher: teacher,
                                       contentType: 'inappropriate',
-                                    );
-
-                                    Navigator.pop(context);
-
-                                    _scaffoldKey.currentState.showSnackBar(
-                                      SnackBar(
-                                        content: Text('ご報告ありがとうございます'),
-                                      ),
                                     );
                                   },
                                 ),
@@ -177,17 +225,11 @@ class Home extends StatelessWidget {
                                     ),
                                   ),
                                   onPressed: () async {
-                                    await model.report(
-                                      user: teacher,
+                                    await this._report(
+                                      context,
+                                      model: model,
+                                      teacher: teacher,
                                       contentType: 'spam',
-                                    );
-
-                                    Navigator.pop(context);
-
-                                    _scaffoldKey.currentState.showSnackBar(
-                                      SnackBar(
-                                        content: Text('ご報告ありがとうございます'),
-                                      ),
                                     );
                                   },
                                 ),

--- a/lib/presentation/home/home_page.dart
+++ b/lib/presentation/home/home_page.dart
@@ -112,7 +112,101 @@ class Home extends StatelessWidget {
                           ),
                         ],
                       ),
-                      onPressed: () {},
+                      onPressed: () async {
+                        Navigator.pop(context);
+
+                        await showDialog(
+                          context: context,
+                          builder: (BuildContext context) {
+                            return SimpleDialog(
+                              titlePadding: EdgeInsets.all(15),
+                              contentPadding: EdgeInsets.all(0),
+                              shape: RoundedRectangleBorder(
+                                borderRadius: BorderRadius.circular(10),
+                              ),
+                              title: Center(
+                                child: Column(
+                                  children: <Widget>[
+                                    Text(
+                                      'ユーザーを報告する',
+                                      style: TextStyle(
+                                        fontSize: 18,
+                                        fontWeight: FontWeight.bold,
+                                      ),
+                                    ),
+                                    SizedBox(height: 5),
+                                    Text(
+                                      '報告したい内容を選択してください',
+                                      style: TextStyle(
+                                        fontSize: 13,
+                                      ),
+                                    ),
+                                  ],
+                                ),
+                              ),
+                              children: <Widget>[
+                                Divider(height: 0.5),
+                                SimpleDialogOption(
+                                  padding: EdgeInsets.all(15),
+                                  child: Center(
+                                    child: Text(
+                                      '不適切な内容である',
+                                    ),
+                                  ),
+                                  onPressed: () async {
+                                    await model.report(
+                                      user: teacher,
+                                      contentType: 'inappropriate',
+                                    );
+
+                                    Navigator.pop(context);
+
+                                    _scaffoldKey.currentState.showSnackBar(
+                                      SnackBar(
+                                        content: Text('ご報告ありがとうございます'),
+                                      ),
+                                    );
+                                  },
+                                ),
+                                Divider(height: 0.5),
+                                SimpleDialogOption(
+                                  padding: EdgeInsets.all(15),
+                                  child: Center(
+                                    child: Text(
+                                      'スパムである',
+                                    ),
+                                  ),
+                                  onPressed: () async {
+                                    await model.report(
+                                      user: teacher,
+                                      contentType: 'spam',
+                                    );
+
+                                    Navigator.pop(context);
+
+                                    _scaffoldKey.currentState.showSnackBar(
+                                      SnackBar(
+                                        content: Text('ご報告ありがとうございます'),
+                                      ),
+                                    );
+                                  },
+                                ),
+                                Divider(height: 0.5),
+                                SimpleDialogOption(
+                                  padding: EdgeInsets.all(15),
+                                  child: Center(
+                                    child: Text('キャンセル'),
+                                  ),
+                                  onPressed: () {
+                                    Navigator.pop(context);
+                                  },
+                                ),
+                                Divider(height: 0.5),
+                              ],
+                            );
+                          },
+                        );
+                      },
                     ),
                   ),
                   ButtonTheme(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -181,6 +181,13 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_dotenv:
+    dependency: "direct main"
+    description:
+      name: flutter_dotenv
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.1.0"
   flutter_facebook_login:
     dependency: "direct main"
     description:
@@ -234,7 +241,7 @@ packages:
     source: hosted
     version: "0.9.1+1"
   http:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: http
       url: "https://pub.dartlang.org"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -29,6 +29,8 @@ dependencies:
   image_picker: ^0.6.7+1
   timeago: ^2.0.26
   image_cropper: ^1.2.3
+  http: ^0.12.2
+  flutter_dotenv: ^2.1.0
 
   # firebase
   firebase_core: ^0.4.5
@@ -62,6 +64,7 @@ flutter:
 
   # To add assets to your application, add an assets section, like this:
   assets:
+    - .env
     - images/google.png
     - images/apple.png
     - images/facebook.png


### PR DESCRIPTION
# Issue
#20

# 内容
- 任意のユーザーを報告する機能の追加
- GSSに報告内容を書き込むGASのWeb APIを呼ぶ処理を追加
- resolve #20

# 確認手順
1. 講師リストに遷移する
2. 任意の報告したいユーザーをロングタップする
   - ModalBottomSheetが表示される
3. 「報告する」ボタンをタップ
   - ModalBottomSheetが閉じ、報告選択のダイアログが表示される
4. 報告したい内容を選択する
   - FirestoreとGSSに報告データが保存されてダイアログが閉じ、SnackBarが表示される