### PR TITLE
認証画面に利用規約とプライバシーポリシーを追加

### DIFF
--- a/lib/presentation/auth/auth_page.dart
+++ b/lib/presentation/auth/auth_page.dart
@@ -1,5 +1,7 @@
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:url_launcher/url_launcher.dart' as launcher;
 import '../common/loading.dart';
 import '../../atoms/rounded_button.dart';
 import '../signup/signup_page.dart';
@@ -31,6 +33,7 @@ class Auth extends StatelessWidget {
                           flex: 3,
                           child: AuthButtonList(),
                         ),
+                        AuthBottom(),
                       ],
                     ),
                   ),
@@ -153,6 +156,63 @@ class EmailLoginButton extends StatelessWidget {
 }
 
 class EmailRegisterButton extends StatelessWidget {
+  Future _alertDialog(BuildContext context, {String errorText}) async {
+    showDialog(
+      context: context,
+      builder: (BuildContext context) {
+        return AlertDialog(
+          title: Text('エラー'),
+          content: Text(errorText),
+          actions: <Widget>[
+            FlatButton(
+              child: Text(
+                'OK',
+                style: TextStyle(
+                  color: Colors.blueAccent,
+                ),
+              ),
+              onPressed: () => Navigator.pop(context),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  Future<bool> _confirmDialog(BuildContext context) async {
+    return showDialog(
+      context: context,
+      builder: (BuildContext context) {
+        return AlertDialog(
+          title: Text('確認'),
+          content: Text(
+            '続けるには利用規約またはプライバシーポリシーに同意する必要があります。',
+          ),
+          actions: <Widget>[
+            FlatButton(
+              child: Text(
+                'キャンセル',
+                style: TextStyle(
+                  color: Colors.blueAccent,
+                ),
+              ),
+              onPressed: () => Navigator.pop(context, false),
+            ),
+            FlatButton(
+              child: Text(
+                '送信',
+                style: TextStyle(
+                  color: Colors.blueAccent,
+                ),
+              ),
+              onPressed: () => Navigator.pop(context, true),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return RoundedButton(
@@ -165,7 +225,7 @@ class EmailRegisterButton extends StatelessWidget {
           fontWeight: FontWeight.bold,
         ),
       ),
-      onPressed: () {
+      onPressed: () async {
         Navigator.push(
           context,
           MaterialPageRoute(
@@ -249,6 +309,91 @@ class FacebookButton extends StatelessWidget {
           print(e.toString());
         }
       },
+    );
+  }
+}
+
+class AuthBottom extends StatelessWidget {
+  Future _alertDialog(BuildContext context, {String errorText}) async {
+    showDialog(
+      context: context,
+      builder: (BuildContext context) {
+        return AlertDialog(
+          title: Text('エラー'),
+          content: Text(errorText),
+          actions: <Widget>[
+            FlatButton(
+              child: Text(
+                'OK',
+                style: TextStyle(
+                  color: Colors.blueAccent,
+                ),
+              ),
+              onPressed: () => Navigator.pop(context),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      child: RichText(
+        text: TextSpan(
+          text: 'ログインすると',
+          style: TextStyle(color: Colors.black54),
+          children: <TextSpan>[
+            TextSpan(
+              text: '利用規約',
+              style: TextStyle(
+                color: Theme.of(context).primaryColor,
+              ),
+              recognizer: TapGestureRecognizer()
+                ..onTap = () async {
+                  try {
+                    const url =
+                        'https://takutore-e2ffa.firebaseapp.com/terms.html';
+                    if (await launcher.canLaunch(url)) {
+                      await launcher.launch(url);
+                    } else {
+                      throw '利用規約の読み込みに失敗しました。';
+                    }
+                  } catch (e) {
+                    this._alertDialog(context, errorText: e.toString());
+                  }
+                },
+            ),
+            TextSpan(
+              text: 'または',
+            ),
+            TextSpan(
+              text: 'プライバシーポリシー',
+              style: TextStyle(
+                color: Theme.of(context).primaryColor,
+              ),
+              recognizer: TapGestureRecognizer()
+                ..onTap = () async {
+                  try {
+                    const url =
+                        'https://takutore-e2ffa.firebaseapp.com/privacy.html';
+                    if (await launcher.canLaunch(url)) {
+                      await launcher.launch(url);
+                    } else {
+                      throw 'プライバシーポリシーの読み込みに失敗しました。';
+                    }
+                  } catch (e) {
+                    this._alertDialog(context, errorText: e.toString());
+                  }
+                },
+            ),
+            TextSpan(
+              text: 'に同意したものとみなされます。',
+            ),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/lib/presentation/login/login_page.dart
+++ b/lib/presentation/login/login_page.dart
@@ -1,5 +1,7 @@
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:url_launcher/url_launcher.dart' as launcher;
 import '../../atoms/rounded_button.dart';
 import '../common/loading.dart';
 import '../../user_model.dart';
@@ -32,6 +34,29 @@ class _LoginState extends State<Login> {
     ];
     _controllers.forEach((_controller) => _controller.dispose());
     myFocusNode.dispose();
+  }
+
+  Future _alertDialog(BuildContext context, {String errorText}) async {
+    showDialog(
+      context: context,
+      builder: (BuildContext context) {
+        return AlertDialog(
+          title: Text('エラー'),
+          content: Text(errorText),
+          actions: <Widget>[
+            FlatButton(
+              child: Text(
+                'OK',
+                style: TextStyle(
+                  color: Colors.blueAccent,
+                ),
+              ),
+              onPressed: () => Navigator.pop(context),
+            ),
+          ],
+        );
+      },
+    );
   }
 
   @override
@@ -128,6 +153,65 @@ class _LoginState extends State<Login> {
                                 );
                               }
                             },
+                          ),
+                          SizedBox(height: 30),
+                          Container(
+                            child: RichText(
+                              text: TextSpan(
+                                text: 'ログインすると',
+                                style: TextStyle(color: Colors.black54),
+                                children: <TextSpan>[
+                                  TextSpan(
+                                    text: '利用規約',
+                                    style: TextStyle(
+                                      color: Theme.of(context).primaryColor,
+                                    ),
+                                    recognizer: TapGestureRecognizer()
+                                      ..onTap = () async {
+                                        try {
+                                          const url =
+                                              'https://takutore-e2ffa.firebaseapp.com/terms.html';
+                                          if (await launcher.canLaunch(url)) {
+                                            await launcher.launch(url);
+                                          } else {
+                                            throw '利用規約の読み込みに失敗しました。';
+                                          }
+                                        } catch (e) {
+                                          this._alertDialog(context,
+                                              errorText: e.toString());
+                                        }
+                                      },
+                                  ),
+                                  TextSpan(
+                                    text: 'または',
+                                  ),
+                                  TextSpan(
+                                    text: 'プライバシーポリシー',
+                                    style: TextStyle(
+                                      color: Theme.of(context).primaryColor,
+                                    ),
+                                    recognizer: TapGestureRecognizer()
+                                      ..onTap = () async {
+                                        try {
+                                          const url =
+                                              'https://takutore-e2ffa.firebaseapp.com/privacy.html';
+                                          if (await launcher.canLaunch(url)) {
+                                            await launcher.launch(url);
+                                          } else {
+                                            throw 'プライバシーポリシーの読み込みに失敗しました。';
+                                          }
+                                        } catch (e) {
+                                          this._alertDialog(context,
+                                              errorText: e.toString());
+                                        }
+                                      },
+                                  ),
+                                  TextSpan(
+                                    text: 'に同意したものとみなされます。',
+                                  ),
+                                ],
+                              ),
+                            ),
                           ),
                         ],
                       ),

--- a/lib/presentation/signup/signup_page.dart
+++ b/lib/presentation/signup/signup_page.dart
@@ -1,5 +1,7 @@
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:url_launcher/url_launcher.dart' as launcher;
 import '../../atoms/rounded_button.dart';
 import '../common/loading.dart';
 import '../../user_model.dart';
@@ -36,6 +38,29 @@ class _SignUpState extends State<SignUp> {
     ];
     _controllers.forEach((_controller) => _controller.dispose());
     myFocusNode.dispose();
+  }
+
+  Future _alertDialog(BuildContext context, {String errorText}) async {
+    showDialog(
+      context: context,
+      builder: (BuildContext context) {
+        return AlertDialog(
+          title: Text('エラー'),
+          content: Text(errorText),
+          actions: <Widget>[
+            FlatButton(
+              child: Text(
+                'OK',
+                style: TextStyle(
+                  color: Colors.blueAccent,
+                ),
+              ),
+              onPressed: () => Navigator.pop(context),
+            ),
+          ],
+        );
+      },
+    );
   }
 
   @override
@@ -173,6 +198,65 @@ class _SignUpState extends State<SignUp> {
                                 );
                               }
                             },
+                          ),
+                          SizedBox(height: 30),
+                          Container(
+                            child: RichText(
+                              text: TextSpan(
+                                text: 'アカウント登録すると',
+                                style: TextStyle(color: Colors.black54),
+                                children: <TextSpan>[
+                                  TextSpan(
+                                    text: '利用規約',
+                                    style: TextStyle(
+                                      color: Theme.of(context).primaryColor,
+                                    ),
+                                    recognizer: TapGestureRecognizer()
+                                      ..onTap = () async {
+                                        try {
+                                          const url =
+                                              'https://takutore-e2ffa.firebaseapp.com/terms.html';
+                                          if (await launcher.canLaunch(url)) {
+                                            await launcher.launch(url);
+                                          } else {
+                                            throw '利用規約の読み込みに失敗しました。';
+                                          }
+                                        } catch (e) {
+                                          this._alertDialog(context,
+                                              errorText: e.toString());
+                                        }
+                                      },
+                                  ),
+                                  TextSpan(
+                                    text: 'または',
+                                  ),
+                                  TextSpan(
+                                    text: 'プライバシーポリシー',
+                                    style: TextStyle(
+                                      color: Theme.of(context).primaryColor,
+                                    ),
+                                    recognizer: TapGestureRecognizer()
+                                      ..onTap = () async {
+                                        try {
+                                          const url =
+                                              'https://takutore-e2ffa.firebaseapp.com/privacy.html';
+                                          if (await launcher.canLaunch(url)) {
+                                            await launcher.launch(url);
+                                          } else {
+                                            throw 'プライバシーポリシーの読み込みに失敗しました。';
+                                          }
+                                        } catch (e) {
+                                          this._alertDialog(context,
+                                              errorText: e.toString());
+                                        }
+                                      },
+                                  ),
+                                  TextSpan(
+                                    text: 'に同意したものとみなされます。',
+                                  ),
+                                ],
+                              ),
+                            ),
                           ),
                         ],
                       ),


### PR DESCRIPTION
# Issue
resolve #42 

# 確認手順
1. アカウントをログアウト状態にする
2. トップ画面の下部に配置した利用規約&プライバシーポリシーをタップする
   - ログイン画面、アカウント登録画面も同様

# スクリーンショット
<img src='https://user-images.githubusercontent.com/36891892/89870054-42593d00-dbf0-11ea-9cb8-a51b5203289a.png' width=200 />　<img src='https://user-images.githubusercontent.com/36891892/89870071-45ecc400-dbf0-11ea-8a9d-4cbe03848f08.png' width=200 />　<img src='https://user-images.githubusercontent.com/36891892/89870072-46855a80-dbf0-11ea-80f2-104260d1bcee.png' width=200 />
