### PR TITLE
トークルーム一覧ページの上部タブバーのUIを修正

### DIFF
--- a/lib/presentation/chat/chat_page.dart
+++ b/lib/presentation/chat/chat_page.dart
@@ -43,21 +43,17 @@ class _ChatState extends State<Chat> with TickerProviderStateMixin {
           bottom: PreferredSize(
             preferredSize: Size(double.infinity, 50),
             child: Container(
-              padding: EdgeInsets.only(bottom: 15),
               height: 50,
               child: TabBar(
+                labelPadding: EdgeInsets.symmetric(horizontal: 0),
                 controller: _tabController,
                 indicatorSize: TabBarIndicatorSize.label,
-                indicator: BoxDecoration(
-                  borderRadius: BorderRadius.circular(20),
-                  color: Theme.of(context).primaryColor,
-                ),
                 labelStyle: TextStyle(
                   fontSize: 16,
                   fontWeight: FontWeight.bold,
                 ),
-                labelColor: Colors.white,
-                unselectedLabelColor: Colors.black87,
+                labelColor: Theme.of(context).primaryColor,
+                unselectedLabelColor: Colors.black45,
                 tabs: [
                   Tab(
                     child: Align(


### PR DESCRIPTION
# Issue
fix #49

# 変更内容
トークルーム一覧ページの上部タブバーのUIを以下のように修正した。

(左：修正前、右：修正後)
<img src='https://user-images.githubusercontent.com/36891892/90011647-eb7d6180-dcdc-11ea-9303-94df51ed99a8.png' width=300 />　<img src='https://user-images.githubusercontent.com/36891892/90011655-ef10e880-dcdc-11ea-9b0f-134db1d2a53c.png' width=300 />
