### PR TITLE
ユーザーを読み込み済みかのnullチェックを追加

### DIFF
--- a/lib/presentation/setting_image/setting_image_page.dart
+++ b/lib/presentation/setting_image/setting_image_page.dart
@@ -61,6 +61,8 @@ class SettingImage extends StatelessWidget {
       create: (_) => SettingImageModel()..fetchCurrentUser(),
       child: Consumer<SettingImageModel>(
         builder: (_, model, __) {
+          if (model.currentUser == null) return SizedBox();
+
           return Stack(
             alignment: Alignment.center,
             children: <Widget>[


### PR DESCRIPTION
# Issue
resolve #58 

# 変更内容
ユーザーの読み込みを終了したかを確認するために、nullチェックを追加した。

# 確認手順
1. 設定ページを開く
2. 画像変更ページを開く
3. コンソールにエラーが出ていないことを確認する