### PR TITLE
募集停止機能を追加

### DIFF
--- a/lib/domain/teacher.dart
+++ b/lib/domain/teacher.dart
@@ -9,6 +9,7 @@ class Teacher extends User {
   String recommend;
   double avgRating;
   int numRatings;
+  bool isRecruiting;
 
   Teacher({
     @required uid,
@@ -24,6 +25,7 @@ class Teacher extends User {
     @required this.recommend,
     @required this.avgRating,
     @required this.numRatings,
+    @required this.isRecruiting,
   }) : super(
           uid: uid,
           displayName: displayName,

--- a/lib/presentation/bookmark/bookmark_model.dart
+++ b/lib/presentation/bookmark/bookmark_model.dart
@@ -45,6 +45,7 @@ class BookmarkModel extends ChangeNotifier {
           avgRating: document['avgRating'].toDouble(),
           numRatings: document['numRatings'].toInt(),
           blockedUserID: document['blockedUserID'],
+          isRecruiting: document['isRecruiting'],
         );
       }),
     );

--- a/lib/presentation/home/home_model.dart
+++ b/lib/presentation/home/home_model.dart
@@ -68,6 +68,7 @@ class HomeModel extends ChangeNotifier {
         avgRating: doc['avgRating'].toDouble(),
         numRatings: doc['numRatings'].toInt(),
         blockedUserID: doc['blockedUserID'],
+        isRecruiting: doc['isRecruiting'],
       );
     }).toList();
 
@@ -105,6 +106,7 @@ class HomeModel extends ChangeNotifier {
         avgRating: doc['avgRating'].toDouble(),
         numRatings: doc['numRatings'].toInt(),
         blockedUserID: doc['blockedUserID'],
+        isRecruiting: doc['isRecruiting'],
       );
     }).toList();
     this.teachers = [...this.teachers, ...teachers];

--- a/lib/presentation/setting_teacher/setting_teacher_model.dart
+++ b/lib/presentation/setting_teacher/setting_teacher_model.dart
@@ -126,6 +126,7 @@ class SettingTeacherModel extends ChangeNotifier {
       'recommend': this._recommend,
       'avgRating': 0.0,
       'numRatings': 0.0,
+      'isRecruiting': true,
     });
   }
 }

--- a/lib/presentation/teacher_detail/teacher_detail_page.dart
+++ b/lib/presentation/teacher_detail/teacher_detail_page.dart
@@ -343,6 +343,23 @@ class ConsultButton extends StatelessWidget {
     return Consumer<TeacherDetailModel>(
       builder: (_, model, __) {
         const horizontalMargin = 30;
+        if (!model.teacher.isRecruiting) {
+          return RoundedButton(
+            minWidth: MediaQuery.of(context).size.width - horizontalMargin,
+            color: Theme.of(context).primaryColor,
+            disabledColor: Colors.grey,
+            onPressed: null,
+            child: Text(
+              'この募集は締め切りました',
+              style: TextStyle(
+                fontWeight: FontWeight.bold,
+                fontSize: 17,
+                color: Colors.white,
+              ),
+            ),
+          );
+        }
+
         return RoundedButton(
           minWidth: MediaQuery.of(context).size.width - horizontalMargin,
           color: Theme.of(context).primaryColor,

--- a/lib/presentation/teacher_edit/teacher_edit_model.dart
+++ b/lib/presentation/teacher_edit/teacher_edit_model.dart
@@ -2,13 +2,13 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:takutore/domain/teacher.dart';
-import 'package:takutore/domain/user.dart';
 
 class TeacherEditModel extends ChangeNotifier {
   final _auth = FirebaseAuth.instance;
   final _store = Firestore.instance;
-  User teacher;
+  Teacher teacher;
   bool isLoading = false;
+  bool isRecruiting = false;
 
   beginLoading() {
     this.isLoading = true;
@@ -20,7 +20,20 @@ class TeacherEditModel extends ChangeNotifier {
     notifyListeners();
   }
 
+  Future switchRecruiting(bool isRecruiting) async {
+    this.isRecruiting = isRecruiting;
+    final currentUser = await _auth.currentUser();
+    await _store.collection('users').document(currentUser.uid).updateData(
+      {
+        'isRecruiting': isRecruiting,
+      },
+    );
+    notifyListeners();
+  }
+
   Future fetchTeacher() async {
+    beginLoading();
+
     final currentUser = await _auth.currentUser();
 
     final userSnapshot =
@@ -37,24 +50,15 @@ class TeacherEditModel extends ChangeNotifier {
       recommend: userSnapshot['recommend'],
       about: userSnapshot['about'],
       blockedUserID: userSnapshot['blockedUserID'],
-      numRatings: userSnapshot['numRatings'],
-      avgRating: userSnapshot['avgRating'],
+      numRatings: userSnapshot['numRatings'].toInt(),
+      avgRating: userSnapshot['avgRating'].toDouble(),
       thumbnail: userSnapshot['thumbnail'],
       isRecruiting: userSnapshot['isRecruiting'],
     );
 
     this.teacher = teacher;
-    notifyListeners();
-  }
+    this.isRecruiting = teacher.isRecruiting;
 
-  Future stopConsulting(consult) async {
-    final currentUser = await _auth.currentUser();
-    await _store.collection('users').document(currentUser.uid).updateData(
-      {
-        'isTeacher': !consult,
-      },
-    );
-    print(consult);
-    notifyListeners();
+    endLoading();
   }
 }

--- a/lib/presentation/teacher_edit/teacher_edit_model.dart
+++ b/lib/presentation/teacher_edit/teacher_edit_model.dart
@@ -40,6 +40,7 @@ class TeacherEditModel extends ChangeNotifier {
       numRatings: userSnapshot['numRatings'],
       avgRating: userSnapshot['avgRating'],
       thumbnail: userSnapshot['thumbnail'],
+      isRecruiting: userSnapshot['isRecruiting'],
     );
 
     this.teacher = teacher;

--- a/lib/presentation/teacher_edit/teacher_edit_page.dart
+++ b/lib/presentation/teacher_edit/teacher_edit_page.dart
@@ -1,119 +1,132 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'teacher_edit_model.dart';
 
 class TeacherEdit extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        title: Text('講師設定'),
-      ),
-      body: Container(
-        child: ListView(
-          children: <Widget>[
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                horizontal: 15,
-                vertical: 10,
-              ),
-              child: Text(
-                '基本設定',
-                style: TextStyle(
-                  fontSize: 18,
-                  fontWeight: FontWeight.bold,
-                  color: Colors.black54,
-                ),
-              ),
-            ),
-            Divider(height: 0.5),
-            Ink(
-              color: Colors.white,
-              child: ListTile(
-                dense: true,
-                contentPadding: EdgeInsets.symmetric(
-                  vertical: 0,
+    return ChangeNotifierProvider<TeacherEditModel>(
+      create: (_) => TeacherEditModel()..fetchTeacher(),
+      child: Scaffold(
+        appBar: AppBar(
+          title: Text('講師設定'),
+        ),
+        body: Container(
+          child: ListView(
+            children: <Widget>[
+              Padding(
+                padding: const EdgeInsets.symmetric(
                   horizontal: 15,
+                  vertical: 10,
                 ),
-                title: Row(
-                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                  children: <Widget>[
-                    Text(
-                      '内容を編集する',
-                      style: TextStyle(
-                        fontSize: 15,
-                        fontWeight: FontWeight.bold,
+                child: Text(
+                  '基本設定',
+                  style: TextStyle(
+                    fontSize: 18,
+                    fontWeight: FontWeight.bold,
+                    color: Colors.black54,
+                  ),
+                ),
+              ),
+              Divider(height: 0.5),
+              Ink(
+                color: Colors.white,
+                child: ListTile(
+                  dense: true,
+                  contentPadding: EdgeInsets.symmetric(
+                    vertical: 0,
+                    horizontal: 15,
+                  ),
+                  title: Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    children: <Widget>[
+                      Text(
+                        '内容を編集する',
+                        style: TextStyle(
+                          fontSize: 15,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                      SizedBox(width: 10),
+                    ],
+                  ),
+                  trailing: Icon(
+                    Icons.arrow_forward_ios,
+                    size: 15,
+                  ),
+                  onTap: () {},
+                ),
+              ),
+              Divider(height: 0.5),
+              Consumer<TeacherEditModel>(
+                builder: (_, model, __) {
+                  return Ink(
+                    color: Colors.white,
+                    child: ListTile(
+                      dense: true,
+                      contentPadding: EdgeInsets.symmetric(
+                        vertical: 0,
+                        horizontal: 15,
+                      ),
+                      title: Row(
+                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                        children: <Widget>[
+                          Text(
+                            '募集を停止する',
+                            style: TextStyle(
+                              fontSize: 15,
+                              fontWeight: FontWeight.bold,
+                            ),
+                          ),
+                          !model.isLoading
+                              ? Switch(
+                                  value: !model.isRecruiting,
+                                  onChanged: (isRecruiting) {
+                                    model.switchRecruiting(!isRecruiting);
+                                  },
+                                )
+                              : SizedBox(),
+                        ],
                       ),
                     ),
-                    SizedBox(width: 10),
-                  ],
-                ),
-                trailing: Icon(
-                  Icons.arrow_forward_ios,
-                  size: 15,
-                ),
-                onTap: () {},
+                  );
+                },
               ),
-            ),
-            Divider(height: 0.5),
-            Ink(
-              color: Colors.white,
-              child: ListTile(
-                dense: true,
-                contentPadding: EdgeInsets.symmetric(
-                  vertical: 0,
-                  horizontal: 15,
-                ),
-                title: Row(
-                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                  children: <Widget>[
-                    Text(
-                      '募集を停止する',
-                      style: TextStyle(
-                        fontSize: 15,
-                        fontWeight: FontWeight.bold,
+              Divider(height: 0.5),
+              SizedBox(height: 15),
+              Divider(height: 0.5),
+              Ink(
+                color: Colors.white,
+                child: ListTile(
+                  dense: true,
+                  contentPadding: EdgeInsets.symmetric(
+                    vertical: 0,
+                    horizontal: 15,
+                  ),
+                  title: Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    children: <Widget>[
+                      Text(
+                        '講師を止める',
+                        style: TextStyle(
+                          fontSize: 15,
+                          fontWeight: FontWeight.bold,
+                          color: Colors.red,
+                        ),
                       ),
-                    ),
-                    Switch(
-                      value: false,
-                      onChanged: (value) => {},
-                    ),
-                  ],
+                      SizedBox(width: 10),
+                    ],
+                  ),
+                  trailing: Icon(
+                    Icons.arrow_forward_ios,
+                    size: 15,
+                  ),
+                  onTap: () {},
                 ),
               ),
-            ),
-            Divider(height: 0.5),
-            SizedBox(height: 15),
-            Divider(height: 0.5),
-            Ink(
-              color: Colors.white,
-              child: ListTile(
-                dense: true,
-                contentPadding: EdgeInsets.symmetric(
-                  vertical: 0,
-                  horizontal: 15,
-                ),
-                title: Row(
-                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                  children: <Widget>[
-                    Text(
-                      '講師を止める',
-                      style: TextStyle(
-                        fontSize: 15,
-                        fontWeight: FontWeight.bold,
-                        color: Colors.red,
-                      ),
-                    ),
-                    SizedBox(width: 10),
-                  ],
-                ),
-                trailing: Icon(
-                  Icons.arrow_forward_ios,
-                  size: 15,
-                ),
-                onTap: () {},
-              ),
-            ),
-            Divider(height: 0.5),
-          ],
+              Divider(height: 0.5),
+            ],
+          ),
         ),
       ),
     );


### PR DESCRIPTION
# Issue
solve #72 

# 変更内容
- isRecruitingカラムを追加
- 募集停止機能を追加

# 確認手順
1. アカウントAで講師設定ページで募集停止Switchをタップして募集を停止する
2. アカウントBで講師一覧ページ＞アカウントAの講師詳細ページに移動する
3. Floatingボタンに停止中と表示されいてタップすることができないことを確認する