### PR TITLE
講師削除機能を追加

### DIFF
--- a/lib/presentation/remove_teacher/remove_teacher_model.dart
+++ b/lib/presentation/remove_teacher/remove_teacher_model.dart
@@ -47,6 +47,14 @@ class RemoveTeacherModel extends ChangeNotifier {
 
     await doc.updateData({
       'isTeacher': false,
+      'thumbnail': FieldValue.delete(),
+      'title': FieldValue.delete(),
+      'canDo': FieldValue.delete(),
+      'recommend': FieldValue.delete(),
+      'about': FieldValue.delete(),
+      'avgRating': FieldValue.delete(),
+      'numRatings': FieldValue.delete(),
+      'isRecruiting': FieldValue.delete(),
     });
     endLoading();
   }

--- a/lib/presentation/teacher_edit/teacher_edit_page.dart
+++ b/lib/presentation/teacher_edit/teacher_edit_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:takutore/presentation/remove_teacher/remove_teacher_page.dart';
 import 'package:takutore/presentation/teacher_edit_form/teacher_edit_form_page.dart';
 import 'teacher_edit_model.dart';
 
@@ -110,34 +111,74 @@ class TeacherEdit extends StatelessWidget {
               Divider(height: 0.5),
               SizedBox(height: 15),
               Divider(height: 0.5),
-              Ink(
-                color: Colors.white,
-                child: ListTile(
-                  dense: true,
-                  contentPadding: EdgeInsets.symmetric(
-                    vertical: 0,
-                    horizontal: 15,
-                  ),
-                  title: Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                    children: <Widget>[
-                      Text(
-                        '講師を止める',
-                        style: TextStyle(
-                          fontSize: 15,
-                          fontWeight: FontWeight.bold,
-                          color: Colors.red,
-                        ),
+              Consumer<TeacherEditModel>(
+                builder: (_, model, __) {
+                  return Ink(
+                    color: Colors.white,
+                    child: ListTile(
+                      dense: true,
+                      contentPadding: EdgeInsets.symmetric(
+                        vertical: 0,
+                        horizontal: 15,
                       ),
-                      SizedBox(width: 10),
-                    ],
-                  ),
-                  trailing: Icon(
-                    Icons.arrow_forward_ios,
-                    size: 15,
-                  ),
-                  onTap: () {},
-                ),
+                      title: Row(
+                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                        children: <Widget>[
+                          Text(
+                            '講師を止める',
+                            style: TextStyle(
+                              fontSize: 15,
+                              fontWeight: FontWeight.bold,
+                              color: Colors.red,
+                            ),
+                          ),
+                          SizedBox(width: 10),
+                        ],
+                      ),
+                      trailing: Icon(
+                        Icons.arrow_forward_ios,
+                        size: 15,
+                      ),
+                      onTap: () async {
+                        try {
+                          if (await model.hasStudents()) {
+                            throw ('相談中の相手がいるため、講師を止めることができません。');
+                          }
+
+                          Navigator.push(
+                            context,
+                            MaterialPageRoute(
+                              builder: (BuildContext context) =>
+                                  RemoveTeacher(),
+                            ),
+                          );
+                        } catch (e) {
+                          showDialog(
+                            context: context,
+                            builder: (BuildContext context) {
+                              return AlertDialog(
+                                title: Text('エラー'),
+                                content: Text(e.toString()),
+                                actions: <Widget>[
+                                  FlatButton(
+                                    child: Text(
+                                      'OK',
+                                      style: TextStyle(
+                                        color: Colors.blueAccent,
+                                        fontWeight: FontWeight.bold,
+                                      ),
+                                    ),
+                                    onPressed: () => Navigator.pop(context),
+                                  ),
+                                ],
+                              );
+                            },
+                          );
+                        }
+                      },
+                    ),
+                  );
+                },
               ),
               Divider(height: 0.5),
             ],


### PR DESCRIPTION
# Issue
resolve #74 

# 変更内容
講師削除機能を追加

# 確認手順
1. 講師設定ページを開き、「講師を止める」をタップする。
2. 既に相談中の相手がいる場合はエラーメッセージが表示され削除できない。誰もいない場合は講師削除ページに遷移する。
3. パスワードを入力してボタンをタップすると講師を削除することができる。