### PR TITLE
アプリのバージョンを表示する機能を追加

### DIFF
--- a/lib/main_model.dart
+++ b/lib/main_model.dart
@@ -6,6 +6,7 @@ import 'package:firebase_remote_config/firebase_remote_config.dart';
 
 class MainModel extends ChangeNotifier {
   bool isRequiredUpdate = false;
+  PackageInfo packageInfo;
 
   Future<void> checkVersion() async {
     final configName =
@@ -15,6 +16,7 @@ class MainModel extends ChangeNotifier {
     await remoteConfig.activateFetched();
     final supportVersion = Version.parse(remoteConfig.getString(configName));
     final packageInfo = await PackageInfo.fromPlatform();
+    this.packageInfo = packageInfo;
     final currentVersion = Version.parse(packageInfo.version);
 
     if (currentVersion < supportVersion) {

--- a/lib/presentation/setting/setting_page.dart
+++ b/lib/presentation/setting/setting_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:takutore/atoms/rounded_button.dart';
+import 'package:takutore/main_model.dart';
 import 'package:takutore/presentation/feedback_form/feedback_form_page.dart';
 import 'package:takutore/presentation/teacher_edit/teacher_edit_page.dart';
 import 'package:url_launcher/url_launcher.dart' as launcher;
@@ -305,6 +306,10 @@ class About extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final applicationVersion = context.select(
+      (MainModel value) => value.packageInfo.version,
+    );
+
     return Section(
       title: SectionTitle(title: 'アプリについて'),
       children: <Widget>[
@@ -375,7 +380,7 @@ class About extends StatelessWidget {
               fontWeight: FontWeight.bold,
             ),
           ),
-          content: '1.0.0',
+          content: applicationVersion,
         ),
         SectionCell(
           title: Text(
@@ -389,7 +394,7 @@ class About extends StatelessWidget {
             try {
               showLicensePage(
                 context: context,
-                applicationVersion: '1.0.0',
+                applicationVersion: applicationVersion,
                 applicationName: 'TakuTore',
               );
             } catch (e) {


### PR DESCRIPTION
## Issue
resolve #99 

## 変更内容
ダウンロードしたアプリのバージョンを取得して表示する機能を追加した。
ハードコーディングではなくリリースする時に設定したバージョンを取得するため、手作業でバージョンを変更する手間が省ける。

## 確認内容
「設定ページ > アプリについて > バージョン」を確認する。