### PR TITLE
講師削除後のナビゲーションを変更

### DIFF
--- a/lib/presentation/remove_teacher/remove_teacher_page.dart
+++ b/lib/presentation/remove_teacher/remove_teacher_page.dart
@@ -21,7 +21,7 @@ class RemoveTeacher extends StatelessWidget {
           titleText: '成功',
           contentText: '登録を解除しました。',
         );
-        Navigator.pop(context);
+        Navigator.popUntil(context, (route) => route.isFirst);
       } catch (e) {
         model.endLoading();
         await _showDialog(


### PR DESCRIPTION
## Issue
close #114 

## 変更内容
講師を削除した後に表示される画面を変更

## 確認方法
1. 講師に登録済みのアカウントで講師設定ページで講師を削除する。
2. 削除後に表示される画面が設定画面であることを確認する。