### PR TITLE
アカウント登録時またはメールアドレス更新時に確認メールを送信する処理を追加

### DIFF
--- a/lib/presentation/signup_email/signup_email_model.dart
+++ b/lib/presentation/signup_email/signup_email_model.dart
@@ -85,6 +85,8 @@ class SignUpEmailModel extends ChangeNotifier {
           }
         },
       );
+
+      await result.user.sendEmailVerification();
     }
   }
 }

--- a/lib/user_model.dart
+++ b/lib/user_model.dart
@@ -282,6 +282,7 @@ class UserModel extends ChangeNotifier {
       ),
     );
     await result.user.updateEmail(email);
+    await result.user.sendEmailVerification();
 
     endLoading();
   }


### PR DESCRIPTION
## Issue
close #131 

## 変更内容
- アカウント登録に成功したときに確認メールを送信する処理を追加
- メールアドレス更新時に確認メールを送信する処理を追加

## 確認手順
1. アカウントを登録すると登録したメールアドレス宛に確認メールが送信されたことを確認する。
2. メールアドレスを更新すると更新後のメールアドレス に確認メールが送信されたことを確認する。