### PR TITLE
AndroidでもFCMで通知できるように設定

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -38,6 +38,11 @@
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
+            <!-- Firebase Cloud Messagingの設定 -->
+            <intent-filter>
+                <action android:name="FLUTTER_NOTIFICATION_CLICK" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
         </activity>
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->


### PR DESCRIPTION
## Issue
close #3 

## 変更内容
AndroidでもFCMで通知できるように設定

## 確認手順
1. Android端末でアカウントにログインし、生成されたFCMトークンを確認する。FCMトークンはFirestoreに保存される。
2. Firebaseコンソール＞Cloud Message＞Send your first messageよりFCMトークンを指定してテストメッセージを送る。
